### PR TITLE
Prevent signature malleability

### DIFF
--- a/packages/lib/src/operations.ts
+++ b/packages/lib/src/operations.ts
@@ -265,6 +265,9 @@ export const assureValidSig = async (
   op: t.CompatibleOpOrTombstone,
 ): Promise<string> => {
   const { sig, ...opData } = op
+  if (sig.endsWith('=')) {
+    throw new InvalidSignatureError(op)
+  }
   const sigBytes = uint8arrays.fromString(sig, 'base64url')
   const dataBytes = new Uint8Array(cbor.encode(opData))
   for (const didKey of allowedDidKeys) {


### PR DESCRIPTION
See rationale here: https://github.com/bluesky-social/atproto/pull/1839

- prevent DER-encoded signatures (https://github.com/bluesky-social/atproto/pull/1839)
- prevent padding on base64url encoded signatures

Closes https://github.com/did-method-plc/did-method-plc/issues/53