### PR TITLE
Add missing index on (did, createdAt)

### DIFF
--- a/packages/server/service/index.js
+++ b/packages/server/service/index.js
@@ -6,15 +6,18 @@ const { Database, PlcServer } = require('..')
 const main = async () => {
   const version = process.env.PLC_VERSION
   const dbCreds = JSON.parse(process.env.DB_CREDS_JSON)
-  const dbMigrateCreds = JSON.parse(process.env.DB_MIGRATE_CREDS_JSON)
   const dbSchema = process.env.DB_SCHEMA || undefined
-  // Migrate using credentialed user
-  const migrateDb = Database.postgres({
-    url: pgUrl(dbMigrateCreds),
-    schema: dbSchema,
-  })
-  await migrateDb.migrateToLatestOrThrow()
-  await migrateDb.close()
+  const enableMigrations = process.env.ENABLE_MIGRATIONS === 'true'
+  if(enableMigrations) {
+    const dbMigrateCreds = JSON.parse(process.env.DB_MIGRATE_CREDS_JSON)
+    // Migrate using credentialed user
+    const migrateDb = Database.postgres({
+      url: pgUrl(dbMigrateCreds),
+      schema: dbSchema,
+    })
+    await migrateDb.migrateToLatestOrThrow()
+    await migrateDb.close()
+  }
   // Use lower-credentialed user to run the app
   const db = Database.postgres({
     url: pgUrl(dbCreds),

--- a/packages/server/src/migrations/20231128T203323431Z-did-createdat-idx.ts
+++ b/packages/server/src/migrations/20231128T203323431Z-did-createdat-idx.ts
@@ -2,12 +2,12 @@ import { Kysely } from 'kysely'
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
-    .createIndex('operations_did_createdAt_index')
+    .createIndex('operations_did_createdat_idx')
     .on('operations')
     .columns(['did', 'createdAt'])
     .execute()
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
-  await db.schema.dropIndex('operations_did_createdAt_index').execute()
+  await db.schema.dropIndex('operations_did_createdat_idx').execute()
 }

--- a/packages/server/src/migrations/20231128T203323431Z-did-createdat-idx.ts
+++ b/packages/server/src/migrations/20231128T203323431Z-did-createdat-idx.ts
@@ -1,0 +1,13 @@
+import { Kysely } from 'kysely'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .createIndex('operations_did_createdAt_index')
+    .on('operations')
+    .columns(['did', 'createdAt'])
+    .execute()
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex('operations_did_createdAt_index').execute()
+}

--- a/packages/server/src/migrations/index.ts
+++ b/packages/server/src/migrations/index.ts
@@ -5,3 +5,4 @@
 export * as _20221020T204908820Z from './20221020T204908820Z-operations-init'
 export * as _20230223T215019669Z from './20230223T215019669Z-refactor'
 export * as _20230406T174552885Z from './20230406T174552885Z-did-locks'
+export * as _20231128T203323431Z from './20231128T203323431Z-did-createdat-idx'


### PR DESCRIPTION
We were missing an index on the operations table for grabbing the most recent operation for a user.

This also adds a flag on the service entry such that migrations are disabled by default (but can be enabled through use of the flag). This lets us run migrations in a more hands on manner (such as creating this index concurrently).