### PR TITLE
server: add basic date validation

### DIFF
--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -30,7 +30,14 @@ export const createRouter = (ctx: AppContext): express.Router => {
       throw new ServerError(400, 'Invalid count parameter')
     }
     const count = Math.min(parsedCount, 1000)
-    const after = req.query.after ? new Date(req.query.after) : undefined
+    let after
+    if (req.query.after) {
+      const timestamp = Date.parse(req.query.after)
+      if (isNaN(timestamp)) {
+        throw new ServerError(400, 'Invalid date in after parameter')
+      }
+      after = new Date(timestamp)
+    }
     const ops = await ctx.db.exportOps(count, after)
     res.setHeader('content-type', 'application/jsonlines')
     res.status(200)


### PR DESCRIPTION
fixes #60 

The `after` GET parameter isn't particularly strict; it just passes the query parameter to the JavaScript `Date` constructor which is then passed through to the database. This change maintains that behavior but returns a 400 error if the `after` parameter isn't parseable rather than a database error and 500.