### PR TITLE
openapi: DidDocument verificationMethod is singular

### DIFF
--- a/website/spec/plc-server-openapi3.yaml
+++ b/website/spec/plc-server-openapi3.yaml
@@ -414,7 +414,7 @@ components:
           items:
             type: string
             example: "at://atproto.com"
-        verificationMethods:
+        verificationMethod:
           type: array
           items:
             type: object


### PR DESCRIPTION
Note that PlcOp is correctly pluralized (not consistent).

closes: https://github.com/did-method-plc/did-method-plc/issues/82