### PR TITLE
Update did:key specification links

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ For `prev` references, the SHA-256 of the previous operation's bytes are encoded
 - `dag-cbor` multibase type (code: 0x71)
 - `sha-256` multihash (code: 0x12)
 
-Rotation keys are serialized as strings using [did:key](https://w3c-ccg.github.io/did-method-key/), and only `secp256k1` ("k256") and NIST P-256 ("p256") are currently supported.
+Rotation keys are serialized as strings using [did:key](https://w3c-ccg.github.io/did-key-spec/), and only `secp256k1` ("k256") and NIST P-256 ("p256") are currently supported.
 
 The signing keys (`verificationMethods`) are also serialized using `did:key` in operations. When rendered in a DID document, signing keys are represented as objects, with the actual keys in multibase encoding, as required by the DID Core specification.
 

--- a/website/spec/v0.1/did-plc.md
+++ b/website/spec/v0.1/did-plc.md
@@ -84,7 +84,7 @@ For `prev` references, the SHA-256 of the previous operation's bytes are encoded
 - `dag-cbor` multibase type (code: 0x71)
 - `sha-256` multihash (code: 0x12)
 
-Rotation keys are serialized as strings using [did:key](https://w3c-ccg.github.io/did-method-key/), and only `secp256k1` ("k256") and NIST P-256 ("p256") are currently supported.
+Rotation keys are serialized as strings using [did:key](https://w3c-ccg.github.io/did-key-spec/), and only `secp256k1` ("k256") and NIST P-256 ("p256") are currently supported.
 
 The signing keys (`verificationMethods`) are also serialized using `did:key` in operations. When rendered in a DID document, signing keys are represented as objects, with the actual keys in multibase encoding, as required by the DID Core specification.
 


### PR DESCRIPTION
Looks like the repo link for `did-method-key` got updated as `did-key-spec`

- https://github.com/w3c-ccg/did-key-spec/commit/ecda981455074c8fa669cce3b858b0d9bc67c4b1