### PR TITLE
slightly bump AKA length for max handle size

### DIFF
--- a/packages/server/src/constraints.ts
+++ b/packages/server/src/constraints.ts
@@ -5,7 +5,7 @@ import { parseDidKey } from '@atproto/crypto'
 
 const MAX_OP_BYTES = 4000
 const MAX_AKA_ENTRIES = 10
-const MAX_AKA_LENGTH = 256
+const MAX_AKA_LENGTH = 258 // max handle length (253) plus at:// prefix (5)
 const MAX_ROTATION_ENTRIES = 10
 const MAX_SERVICE_ENTRIES = 10
 const MAX_SERVICE_TYPE_LENGTH = 256


### PR DESCRIPTION
I'm not super confident about this one, because I think that some folks have successfully set the max handle length? And it is a corner-case, but it has been aesthetically pleasing to allow the maximum permissible domain hostname as a handle, and it is only a couple bytes away so might as well bump.