### PR TITLE
tighten some field size limits

### DIFF
--- a/packages/server/src/constraints.ts
+++ b/packages/server/src/constraints.ts
@@ -8,8 +8,8 @@ const MAX_AKA_ENTRIES = 10
 const MAX_AKA_LENGTH = 256
 const MAX_ROTATION_ENTRIES = 10
 const MAX_SERVICE_ENTRIES = 10
-const MAX_SERVICE_TYPE_LENGTH = 256
-const MAX_SERVICE_ENDPOINT_LENGTH = 512
+const MAX_SERVICE_TYPE_LENGTH = 96
+const MAX_SERVICE_ENDPOINT_LENGTH = 256
 const MAX_ID_LENGTH = 32
 
 export function validateIncomingOp(input: unknown): plc.OpOrTombstone {


### PR DESCRIPTION
- service `type` length from 256 down to 96
- service endpoint URL length from 512 down to 256

At the end of the day, the 4000 byte overall op limit is the real lever, but these seem safer to tweak as a start. We should do a quick audit before dropping the overall size limit.