### PR TITLE
Limit cross-origin requests to HEAD, GET

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -51,6 +51,7 @@
     "pino-http": "^8.3.3"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.17",
     "@types/pg": "^8.6.5",
     "eslint-plugin-prettier": "^4.2.1"
   }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -36,7 +36,7 @@ export class PlcServer {
   }): PlcServer {
     const app = express()
     app.use(express.json({ limit: '100kb' }))
-    app.use(cors())
+    app.use(cors({ methods: ['HEAD', 'GET'] }))
 
     app.use(loggerMiddleware)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2274,6 +2274,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/cors@^2.8.17":
+  version "2.8.17"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.17.tgz#5d718a5e494a8166f569d986794e49c48b216b2b"
+  integrity sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/graceful-fs@^4.1.3":
   version "4.1.5"
   resolved "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz"


### PR DESCRIPTION
Restricts CORS requests to only HEAD and GET, notably not permitting POST.  This would have the effect of disallowing ops submitted via the browser on sites other than plc.directory.