### PR TITLE
Fix response type for /log/last

### DIFF
--- a/website/spec/plc-server-openapi3.yaml
+++ b/website/spec/plc-server-openapi3.yaml
@@ -134,7 +134,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LogEntry'
+                $ref: '#/components/schemas/Operation'
         '404':
           $ref: '#/components/responses/404DidNotFound'
   /{did}/data:


### PR DESCRIPTION
This endpoint returns `Operation`, not `LogEntry`.