### PR TITLE
Relax constraints on service key formats

### DIFF
--- a/packages/server/src/constraints.ts
+++ b/packages/server/src/constraints.ts
@@ -1,7 +1,7 @@
 import { DAY, HOUR, cborEncode } from '@atproto/common'
 import * as plc from '@did-plc/lib'
 import { ServerError } from './error'
-import { parseDidKey } from '@atproto/crypto'
+import { extractMultikey, parseDidKey } from '@atproto/crypto'
 
 const MAX_OP_BYTES = 4000
 const MAX_AKA_ENTRIES = 10
@@ -111,8 +111,11 @@ export function validateIncomingOp(input: unknown): plc.OpOrTombstone {
         `Verification Method id too long (max ${MAX_ID_LENGTH}): ${id}`,
       )
     }
-    // perform only minimal did:key syntax checking
-    if (!key.startsWith('did:key:')) {
+    try {
+      // perform only minimal did:key syntax checking, with no restrictions on
+      // key types
+      extractMultikey(key)
+    } catch (err) {
       throw new ServerError(400, `Invalid verificationMethod key: ${key}`)
     }
   }

--- a/packages/server/src/constraints.ts
+++ b/packages/server/src/constraints.ts
@@ -111,9 +111,8 @@ export function validateIncomingOp(input: unknown): plc.OpOrTombstone {
         `Verification Method id too long (max ${MAX_ID_LENGTH}): ${id}`,
       )
     }
-    try {
-      parseDidKey(key)
-    } catch (err) {
+    // perform only minimal did:key syntax checking
+    if (!key.startsWith('did:key:')) {
       throw new ServerError(400, `Invalid verificationMethod key: ${key}`)
     }
   }

--- a/packages/server/tests/server.test.ts
+++ b/packages/server/tests/server.test.ts
@@ -107,6 +107,9 @@ describe('PLC server', () => {
       'did:key:z6MkjwbBXZnFqL8su24wGL2Fdjti6GSLv9SWdYGswfazUPm9'
 
     await client.updateAtprotoKey(did, rotationKey1, newSigningKey)
+
+    // put the old key back so as not to disrupt the other tests
+    await client.updateAtprotoKey(did, rotationKey1, signingKey.did())
   })
 
   it('does not allow syntactically invalid service keys', async () => {
@@ -235,7 +238,7 @@ describe('PLC server', () => {
   it('exports the data set', async () => {
     const data = await client.export()
     expect(data.every((row) => check.is(row, plc.def.exportedOp))).toBeTruthy()
-    expect(data.length).toBe(29)
+    expect(data.length).toBe(31)
     for (let i = 1; i < data.length; i++) {
       expect(data[i].createdAt >= data[i - 1].createdAt).toBeTruthy()
     }

--- a/packages/server/tests/server.test.ts
+++ b/packages/server/tests/server.test.ts
@@ -106,7 +106,18 @@ describe('PLC server', () => {
     const newSigningKey =
       'did:key:z6MkjwbBXZnFqL8su24wGL2Fdjti6GSLv9SWdYGswfazUPm9'
 
+    // Note: atproto itself does not currently support ed25519 keys, but PLC
+    // does not have opinions about atproto (or other services!)
     await client.updateAtprotoKey(did, rotationKey1, newSigningKey)
+
+    // a BLS12-381 key
+    const exoticSigningKeyFromTheFuture =
+      'did:key:zUC7K4ndUaGZgV7Cp2yJy6JtMoUHY6u7tkcSYUvPrEidqBmLCTLmi6d5WvwnUqejscAkERJ3bfjEiSYtdPkRSE8kSa11hFBr4sTgnbZ95SJj19PN2jdvJjyzpSZgxkyyxNnBNnY'
+    await client.updateAtprotoKey(
+      did,
+      rotationKey1,
+      exoticSigningKeyFromTheFuture,
+    )
 
     // put the old key back so as not to disrupt the other tests
     await client.updateAtprotoKey(did, rotationKey1, signingKey.did())


### PR DESCRIPTION
PLC Rotation keys continue to be locked down to only the blessed formats, whereas service keys can be arbitrary.

Currently, no attempt is made to validate the multibase syntax (i.e. we only check for a `did:key:` prefix), although this decision is not final.

In the context of atproto, further format constraints may still be applied in the `com.atproto.identity.submitPlcOperation` API, preventing people from *accidentally* setting service keys that are invalid.

Part of the way to fixing #92 (changes on the PDS side may also be necessary)