### PR TITLE
fix: allow GHCR publish to local repo, remove invalid prefix and add multi-arch support

### DIFF
--- a/.github/workflows/build-and-push-ghcr.yaml
+++ b/.github/workflows/build-and-push-ghcr.yaml
@@ -72,6 +72,11 @@ jobs:
       # The receiver opens a pull request pinning the digest with auto-merge
       # enabled, and HCP applies dev on every commit to infra-central's `main`,
       # so merging it is what deploys. Prod pins are promoted by hand.
+      #
+      # This workflow has no `concurrency` guard, so two pushes to `main` build
+      # side by side and finish in whatever order the arm64 legs happen to take.
+      # Last dispatch wins at the receiver, so the tip check below is what keeps
+      # an older build from repinning dev behind a newer one.
       - name: Resolve the source pull request
         if: github.ref == 'refs/heads/main' && github.repository == 'fil-forge/did-method-plc'
         id: source
@@ -94,8 +99,29 @@ jobs:
           owner: fil-forge
           repositories: infra-central
 
-      - name: Request a digest bump in the Forge Central "dev" environment
+      # Kept adjacent to the dispatch so the window between the two is as
+      # small as it can be. The bot token cannot read this repository, so the
+      # tip comes from GITHUB_TOKEN.
+      - name: Confirm this commit is still the tip of main
         if: github.ref == 'refs/heads/main' && github.repository == 'fil-forge/did-method-plc'
+        id: tip
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tip=$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq .sha)
+          if [ "$tip" = "$GITHUB_SHA" ]; then
+            echo "is_tip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_tip=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::main has moved to $tip; leaving the dev pin to that build"
+          fi
+
+      - name: Request a digest bump in the Forge Central "dev" environment
+        if: |
+          github.ref == 'refs/heads/main'
+          && github.repository == 'fil-forge/did-method-plc'
+          && steps.tip.outputs.is_tip == 'true'
         env:
           GH_TOKEN: ${{ steps.bot.outputs.token }}
           DIGEST: ${{ steps.build-and-push.outputs.digest }}

--- a/.github/workflows/build-and-push-ghcr.yaml
+++ b/.github/workflows/build-and-push-ghcr.yaml
@@ -17,6 +17,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      pull-requests: read
 
     steps:
       - name: Checkout repository
@@ -62,3 +63,56 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # The dev stage of Forge Central pins this image by digest rather than
+      # following the `main` tag, so the run that published it is the one that
+      # knows what to deploy. Only fil-forge's `main` builds feed that stage;
+      # other refs and forks publish to their own namespace and stop there.
+      #
+      # The receiver opens a pull request pinning the digest with auto-merge
+      # enabled, and HCP applies dev on every commit to infra-central's `main`,
+      # so merging it is what deploys. Prod pins are promoted by hand.
+      - name: Resolve the source pull request
+        if: github.ref == 'refs/heads/main' && github.repository == 'fil-forge/did-method-plc'
+        id: source
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          pr_url=$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/pulls" \
+            --jq 'map(select(.merged_at != null)) | .[0].html_url // ""')
+          echo "pr_url=$pr_url" >> "$GITHUB_OUTPUT"
+
+      # Needs the FORGE_BOT_APP_ID variable and FORGE_BOT_PRIVATE_KEY secret.
+      - name: Mint fil-forge-bot token
+        if: github.ref == 'refs/heads/main' && github.repository == 'fil-forge/did-method-plc'
+        id: bot
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.FORGE_BOT_APP_ID }}
+          private-key: ${{ secrets.FORGE_BOT_PRIVATE_KEY }}
+          owner: fil-forge
+          repositories: infra-central
+
+      - name: Request a digest bump in the Forge Central "dev" environment
+        if: github.ref == 'refs/heads/main' && github.repository == 'fil-forge/did-method-plc'
+        env:
+          GH_TOKEN: ${{ steps.bot.outputs.token }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+          PR_URL: ${{ steps.source.outputs.pr_url }}
+        run: |
+          set -euo pipefail
+          [[ "$DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]] \
+            || { echo "::error::unexpected digest: '$DIGEST'"; exit 1; }
+          jq -n \
+            --arg service plc \
+            --arg digest "$DIGEST" \
+            --arg source_repo "$GITHUB_REPOSITORY" \
+            --arg commit "$GITHUB_SHA" \
+            --arg pr_url "$PR_URL" \
+            --arg run_url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            '{event_type: "bump-deployed-image",
+              client_payload: {service: $service, digest: $digest,
+                               source_repo: $source_repo, commit: $commit,
+                               pr_url: $pr_url, run_url: $run_url}}' \
+            | gh api --method POST repos/fil-forge/infra-central/dispatches --input -

--- a/.github/workflows/build-and-push-ghcr.yaml
+++ b/.github/workflows/build-and-push-ghcr.yaml
@@ -70,8 +70,9 @@ jobs:
       # other refs and forks publish to their own namespace and stop there.
       #
       # The receiver opens a pull request pinning the digest with auto-merge
-      # enabled, and HCP applies dev on every commit to infra-central's `main`,
-      # so merging it is what deploys. Prod pins are promoted by hand.
+      # enabled, and infra-central's "Check and deploy" runs `tofu apply` on
+      # dev/apps on every push to its `main`, so merging it is what deploys.
+      # Prod pins are promoted by hand.
       #
       # This workflow has no `concurrency` guard, so two pushes to `main` build
       # side by side and finish in whatever order the arm64 legs happen to take.

--- a/.github/workflows/build-and-push-ghcr.yaml
+++ b/.github/workflows/build-and-push-ghcr.yaml
@@ -9,7 +9,9 @@ env:
 
 jobs:
   plc-container-ghcr:
-    if: github.repository == 'did-method-plc/did-method-plc'
+    # IMAGE_NAME is ${{ github.repository }}, so each fork publishes to its own
+    # ghcr namespace (e.g. ghcr.io/fil-forge/did-method-plc). No repo guard is
+    # needed; PR builds are prevented from pushing by the `push:` condition below.
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -36,8 +38,13 @@ jobs:
         with:
           images: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # A colon is illegal in a Docker tag, so the old `prefix=plc:` produced
+          # an unpullable reference. Emit a branch tag (e.g. `main`), release
+          # tags, and a bare full-SHA tag for precise pinning.
           tags: |
-            type=sha,enable=true,priority=100,prefix=plc:,suffix=,format=long
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,prefix=,format=long
 
       - name: Build and push Docker image
         id: build-and-push

--- a/.github/workflows/build-and-push-ghcr.yaml
+++ b/.github/workflows/build-and-push-ghcr.yaml
@@ -22,6 +22,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      # QEMU enables the arm64 leg of the multi-arch build on the amd64 runner.
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v1
 
@@ -52,6 +56,7 @@ jobs:
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
           file: ./packages/server/Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
These are the changes I need to make to allow my local fork to publish to GHCR.

Can you either make the existing package public and/or accept the change in the PR here? Claude thinks the prefix is invalid.

Also adds multi-arch support (linux amd64 and arm64).