### PR TITLE
Reject Non-PLC DIDs On Lookup

### DIFF
--- a/packages/server/src/error.ts
+++ b/packages/server/src/error.ts
@@ -7,12 +7,14 @@ export const handler: ErrorRequestHandler = (err, req, res, next) => {
     err = ServerError.fromPlcError(err)
   }
 
-  req.log.info(
-    err,
-    ServerError.is(err)
-      ? 'handled server error'
-      : 'unexpected internal server error',
-  )
+  if (ServerError.is(err) && err.status < 500) {
+    req.log.debug(
+      { error: { message: err.message, status: err.status } },
+      'handled server error',
+    )
+  } else {
+    req.log.error(err, 'unexpected internal server error')
+  }
   if (res.headersSent) {
     return next(err)
   }

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -13,6 +13,22 @@ import { Outbox, OutboxError } from './sequencer'
 // the outbox, which closes them if they fall too far behind — rather than
 // buffering events in process memory without bound.
 const MAX_WS_BUFFERED_BYTES = 256 * 1024
+const PLC_DID_RE = /^did:plc:[a-z2-7]{24}$/
+
+// Invalid DID methods are a common crawler input. Preserve the existing 404
+// response while avoiding a database round trip and Error stack allocation.
+const requirePlcDid: express.RequestHandler<{ did: string }> = (
+  req,
+  res,
+  next,
+) => {
+  const { did } = req.params
+  if (!PLC_DID_RE.test(did)) {
+    res.status(404).json({ message: `DID not registered: ${did}` })
+    return
+  }
+  next()
+}
 
 export const createRouter = (ctx: AppContext): express.Router => {
   const router = express.Router()
@@ -136,7 +152,7 @@ export const createRouter = (ctx: AppContext): express.Router => {
   })
 
   // Get data for a DID document
-  router.get('/:did', async function (req, res) {
+  router.get('/:did', requirePlcDid, async function (req, res) {
     const { did } = req.params
     const last = await ctx.db.lastOpForDid(did)
     if (!last) {
@@ -152,7 +168,7 @@ export const createRouter = (ctx: AppContext): express.Router => {
   })
 
   // Get data for a DID document
-  router.get('/:did/data', async function (req, res) {
+  router.get('/:did/data', requirePlcDid, async function (req, res) {
     const { did } = req.params
     const last = await ctx.db.lastOpForDid(did)
     if (!last) {
@@ -166,7 +182,7 @@ export const createRouter = (ctx: AppContext): express.Router => {
   })
 
   // Get operation log for a DID
-  router.get('/:did/log', async function (req, res) {
+  router.get('/:did/log', requirePlcDid, async function (req, res) {
     const { did } = req.params
     const log = await ctx.db.opsForDid(did)
     if (log.length === 0) {
@@ -176,7 +192,7 @@ export const createRouter = (ctx: AppContext): express.Router => {
   })
 
   // Get operation log for a DID
-  router.get('/:did/log/audit', async function (req, res) {
+  router.get('/:did/log/audit', requirePlcDid, async function (req, res) {
     const { did } = req.params
     const ops = await ctx.db.indexedOpsForDid(did, true)
     if (ops.length === 0) {
@@ -192,7 +208,7 @@ export const createRouter = (ctx: AppContext): express.Router => {
   })
 
   // Get the most recent operation in the log for a DID
-  router.get('/:did/log/last', async function (req, res) {
+  router.get('/:did/log/last', requirePlcDid, async function (req, res) {
     const { did } = req.params
     const last = await ctx.db.lastOpForDid(did)
     if (!last) {

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -15,19 +15,16 @@ import { Outbox, OutboxError } from './sequencer'
 const MAX_WS_BUFFERED_BYTES = 256 * 1024
 const PLC_DID_RE = /^did:plc:[a-z2-7]{24}$/
 
-// Invalid DID methods are a common crawler input. Preserve the existing 404
-// response while avoiding a database round trip and Error stack allocation.
-const requirePlcDid: express.RequestHandler<{ did: string }> = (
-  req,
-  res,
-  next,
-) => {
-  const { did } = req.params
+// Invalid DID methods are a common crawler input. Reject them before a
+// database round trip with a response that distinguishes unsupported methods
+// from unregistered PLC DIDs.
+const assertPlcDid = (did: string): void => {
   if (!PLC_DID_RE.test(did)) {
-    res.status(404).json({ message: `DID not registered: ${did}` })
-    return
+    throw new ServerError(
+      400,
+      `Resolution of non-PLC DIDs not supported: ${did}`,
+    )
   }
-  next()
 }
 
 export const createRouter = (ctx: AppContext): express.Router => {
@@ -152,8 +149,9 @@ export const createRouter = (ctx: AppContext): express.Router => {
   })
 
   // Get data for a DID document
-  router.get('/:did', requirePlcDid, async function (req, res) {
+  router.get('/:did', async function (req, res) {
     const { did } = req.params
+    assertPlcDid(did)
     const last = await ctx.db.lastOpForDid(did)
     if (!last) {
       throw new ServerError(404, `DID not registered: ${did}`)
@@ -168,8 +166,9 @@ export const createRouter = (ctx: AppContext): express.Router => {
   })
 
   // Get data for a DID document
-  router.get('/:did/data', requirePlcDid, async function (req, res) {
+  router.get('/:did/data', async function (req, res) {
     const { did } = req.params
+    assertPlcDid(did)
     const last = await ctx.db.lastOpForDid(did)
     if (!last) {
       throw new ServerError(404, `DID not registered: ${did}`)
@@ -182,8 +181,9 @@ export const createRouter = (ctx: AppContext): express.Router => {
   })
 
   // Get operation log for a DID
-  router.get('/:did/log', requirePlcDid, async function (req, res) {
+  router.get('/:did/log', async function (req, res) {
     const { did } = req.params
+    assertPlcDid(did)
     const log = await ctx.db.opsForDid(did)
     if (log.length === 0) {
       throw new ServerError(404, `DID not registered: ${did}`)
@@ -192,8 +192,9 @@ export const createRouter = (ctx: AppContext): express.Router => {
   })
 
   // Get operation log for a DID
-  router.get('/:did/log/audit', requirePlcDid, async function (req, res) {
+  router.get('/:did/log/audit', async function (req, res) {
     const { did } = req.params
+    assertPlcDid(did)
     const ops = await ctx.db.indexedOpsForDid(did, true)
     if (ops.length === 0) {
       throw new ServerError(404, `DID not registered: ${did}`)
@@ -208,8 +209,9 @@ export const createRouter = (ctx: AppContext): express.Router => {
   })
 
   // Get the most recent operation in the log for a DID
-  router.get('/:did/log/last', requirePlcDid, async function (req, res) {
+  router.get('/:did/log/last', async function (req, res) {
     const { did } = req.params
+    assertPlcDid(did)
     const last = await ctx.db.lastOpForDid(did)
     if (!last) {
       throw new ServerError(404, `DID not registered: ${did}`)

--- a/packages/server/tests/server.test.ts
+++ b/packages/server/tests/server.test.ts
@@ -388,22 +388,30 @@ describe('PLC server', () => {
     expect(removedOps).toEqual([res.operation]) // should return the removed op
   })
 
-  it('rejects non-PLC identifiers without querying the database', async () => {
+  it('rejects non-PLC identifiers before querying the database', async () => {
     const lastOpForDid = jest.spyOn(db, 'lastOpForDid')
-    const invalidDid = 'did:web:pluralistic.net'
+    const opsForDid = jest.spyOn(db, 'opsForDid')
+    const indexedOpsForDid = jest.spyOn(db, 'indexedOpsForDid')
+    const invalidDid = 'did:web:example.com'
 
     try {
-      const res = await axios.get(`${client.url}/${invalidDid}`, {
-        validateStatus: () => true,
-      })
+      for (const path of ['', '/data', '/log', '/log/audit', '/log/last']) {
+        const res = await axios.get(`${client.url}/${invalidDid}${path}`, {
+          validateStatus: () => true,
+        })
 
-      expect(res.status).toEqual(404)
-      expect(res.data).toEqual({
-        message: `DID not registered: ${invalidDid}`,
-      })
+        expect(res.status).toEqual(400)
+        expect(res.data).toEqual({
+          message: `Resolution of non-PLC DIDs not supported: ${invalidDid}`,
+        })
+      }
       expect(lastOpForDid).not.toHaveBeenCalled()
+      expect(opsForDid).not.toHaveBeenCalled()
+      expect(indexedOpsForDid).not.toHaveBeenCalled()
     } finally {
       lastOpForDid.mockRestore()
+      opsForDid.mockRestore()
+      indexedOpsForDid.mockRestore()
     }
   })
 

--- a/packages/server/tests/server.test.ts
+++ b/packages/server/tests/server.test.ts
@@ -388,6 +388,25 @@ describe('PLC server', () => {
     expect(removedOps).toEqual([res.operation]) // should return the removed op
   })
 
+  it('rejects non-PLC identifiers without querying the database', async () => {
+    const lastOpForDid = jest.spyOn(db, 'lastOpForDid')
+    const invalidDid = 'did:web:pluralistic.net'
+
+    try {
+      const res = await axios.get(`${client.url}/${invalidDid}`, {
+        validateStatus: () => true,
+      })
+
+      expect(res.status).toEqual(404)
+      expect(res.data).toEqual({
+        message: `DID not registered: ${invalidDid}`,
+      })
+      expect(lastOpForDid).not.toHaveBeenCalled()
+    } finally {
+      lastOpForDid.mockRestore()
+    }
+  })
+
   it('healthcheck succeeds when database is available.', async () => {
     const res = await client.health()
     expect(res).toEqual({ version: '0.0.0' })


### PR DESCRIPTION
This should keep a substantial amount of load off the database as folks are requesting odd other types of DIDs.