### PR TITLE
Fix event replay on /export/stream and the two flaky test suites

### DIFF
--- a/packages/lib/tests/recovery.test.ts
+++ b/packages/lib/tests/recovery.test.ts
@@ -170,7 +170,10 @@ describe('plc recovery', () => {
         operation: tombstone,
         cid,
         nullified: false,
-        createdAt: new Date(),
+        // Must be strictly before the proposed op's timestamp: assureValidNextOp
+        // requires timestamps to increase. Dating it with `new Date()` puts it
+        // in the same millisecond whenever signing below is fast enough.
+        createdAt: new Date(Date.now() - HOUR),
       },
     ]
     const rotateBack = await signOpForKeys(

--- a/packages/lib/vitest.config.ts
+++ b/packages/lib/vitest.config.ts
@@ -5,11 +5,5 @@ export default defineConfig({
     setupFiles: ['../../test-setup.ts'],
     testTimeout: 30_000,
     include: ['tests/**/*.{test,spec}.ts'],
-    // Provisional: a pre-existing timing race flakes this suite
-    // (recovery.test.ts "allows recovery from a tombstoned DID" -
-    // same-millisecond timestamp collision, ~1 run in 5-8).
-    // Retries keep CI legible until that race is fixed properly.
-    // Remove this once it is.
-    retry: 2,
   },
 })

--- a/packages/server/src/sequencer/outbox.ts
+++ b/packages/server/src/sequencer/outbox.ts
@@ -63,6 +63,13 @@ export class Outbox {
         throw new OutboxError(CloseReason.OutdatedCursor)
       }
 
+      // Seed the floor with the cursor. The sequencer emits from its own poll
+      // position, which can lag behind this subscriber's cursor, so without a
+      // floor the dedupe below admits events the subscriber has already seen.
+      // Backfill yielding nothing (cursor already at head) is exactly when that
+      // happens.
+      this.lastSeen = backfillCursor
+
       for await (const evt of this.getBackfill(backfillCursor)) {
         if (signal?.aborted) return
         this.lastSeen = evt.seq

--- a/packages/server/tests/sequencer.test.ts
+++ b/packages/server/tests/sequencer.test.ts
@@ -438,9 +438,51 @@ describe('sequencer', () => {
         CloseReason.ConsumerTooSlow,
       )
 
+      // overloadBuffer() rejects by design, and Promise.all short-circuits on
+      // rejection, so the 20 creations above can still be in flight here.
+      // Await them before resyncing, otherwise the cursor lands short and the
+      // stragglers are delivered to whichever test reads next.
+      await createPromise
+
       // Update lastSeen from db
       const fromDb = await loadFromDb(lastSeen)
       lastSeen = fromDb.at(-1)?.seq ?? lastSeen
+    })
+
+    it('does not replay events at or before the cursor', async () => {
+      // The sequencer polls from its own position and emits that whole range to
+      // every subscriber, so a subscriber whose cursor is already at the head
+      // can be handed events it has already seen. Re-emitting an
+      // already-sequenced range reproduces that without depending on poll
+      // timing.
+      const catchUp = await loadFromDb(lastSeen)
+      lastSeen = catchUp.at(-1)?.seq ?? lastSeen
+
+      const outbox = new Outbox(sequencer)
+      const gen = outbox.events(lastSeen)
+
+      const createPromise = (async () => {
+        await createDid(client)
+        await waitForSequencing()
+      })()
+
+      // The generator body only runs on the first next(), and it registers its
+      // sequencer listener after backfill. Start reading first, then wait for
+      // that listener, or the emit below lands before anyone is subscribed.
+      const before = sequencer.listenerCount('events')
+      const reading = readFromGenerator(gen, caughtUp(outbox), createPromise)
+      while (sequencer.listenerCount('events') === before) {
+        await wait(5)
+      }
+
+      const overlapping = await loadFromDb(Math.max(lastSeen - 3, 0))
+      expect(overlapping.some((evt) => evt.seq <= lastSeen)).toBe(true)
+      sequencer.emit('events', overlapping)
+
+      const evts = await reading
+      expect(evts.every((evt) => evt.seq > lastSeen)).toBe(true)
+
+      lastSeen = evts.at(-1)?.seq ?? lastSeen
     })
 
     it('handles many concurrent connections', async () => {

--- a/packages/server/tests/sequencer.test.ts
+++ b/packages/server/tests/sequencer.test.ts
@@ -450,11 +450,10 @@ describe('sequencer', () => {
     })
 
     it('does not replay events at or before the cursor', async () => {
-      // The sequencer polls from its own position and emits that whole range to
-      // every subscriber, so a subscriber whose cursor is already at the head
-      // can be handed events it has already seen. Re-emitting an
-      // already-sequenced range reproduces that without depending on poll
-      // timing.
+      // The sequencer's poll position is independent of any subscriber's
+      // cursor, so a subscriber that read ahead through the db sits in front of
+      // it and the next poll emits a range it has already seen. Winding the
+      // poll position back reproduces that without waiting on poll timing.
       const catchUp = await loadFromDb(lastSeen)
       lastSeen = catchUp.at(-1)?.seq ?? lastSeen
 
@@ -467,17 +466,26 @@ describe('sequencer', () => {
       })()
 
       // The generator body only runs on the first next(), and it registers its
-      // sequencer listener after backfill. Start reading first, then wait for
-      // that listener, or the emit below lands before anyone is subscribed.
+      // sequencer listener after backfill. Start reading first and wait for
+      // that listener, or the poll below lands before anyone is subscribed.
       const before = sequencer.listenerCount('events')
       const reading = readFromGenerator(gen, caughtUp(outbox), createPromise)
       while (sequencer.listenerCount('events') === before) {
         await wait(5)
       }
 
-      const overlapping = await loadFromDb(Math.max(lastSeen - 3, 0))
-      expect(overlapping.some((evt) => evt.seq <= lastSeen)).toBe(true)
-      sequencer.emit('events', overlapping)
+      const emitted: SeqEvt[] = []
+      const capture = (evts: SeqEvt[]) => {
+        emitted.push(...evts)
+      }
+      sequencer.on('events', capture)
+      sequencer.lastSeen = Math.max(lastSeen - 3, 0)
+      await sequencer.pollDb()
+      sequencer.off('events', capture)
+
+      // The poll has to have actually re-emitted something the subscriber saw,
+      // otherwise the assertion below passes for the wrong reason.
+      expect(emitted.some((evt) => evt.seq <= lastSeen)).toBe(true)
 
       const evts = await reading
       expect(evts.every((evt) => evt.seq > lastSeen)).toBe(true)

--- a/packages/server/vitest.config.ts
+++ b/packages/server/vitest.config.ts
@@ -5,11 +5,5 @@ export default defineConfig({
     setupFiles: ['../../test-setup.ts'],
     testTimeout: 30_000,
     include: ['tests/**/*.{test,spec}.ts'],
-    // Provisional: a pre-existing timing race flakes this suite
-    // (sequencer.test.ts "handles many concurrent connections" -
-    // producer/consumer timing race in the test's own logic, ~2 runs in 6).
-    // Retries keep CI legible until that race is fixed properly.
-    // Remove this once it is.
-    retry: 2,
   },
 })


### PR DESCRIPTION
A subscriber that reconnects to `/export/stream` with a cursor at the head can be sent operations it has already received, which breaks the documented contract that the stream starts after the cursor.

`Outbox` filters events against `lastSeen`, which starts at `-1` and only advances while backfill is producing events. A caught-up subscriber leaves it at `-1`, so nothing gets filtered, and the sequencer polls from its own position, which can sit behind that subscriber's cursor. Seeding `lastSeen` with the cursor gives the filter a floor.

Also fixes the two flaky suites the vitest retries were covering. The sequencer's buffer-overload test resynced a shared cursor while its own operations were still in flight, leaving stragglers for the next test. The tombstone test dated two operations in the same millisecond, which is correctly rejected as misordered. Retries are removed from both configs.
