### PR TITLE
Fix 500s on malformed request bodies, close sockets on failed websocket upgrades

### DIFF
--- a/packages/server/src/error.ts
+++ b/packages/server/src/error.ts
@@ -1,5 +1,5 @@
 import { PlcError } from '@did-plc/lib'
-import type { ErrorRequestHandler } from 'express'
+import type { ErrorRequestHandler, Request } from 'express'
 
 export const handler: ErrorRequestHandler = (err, req, res, next) => {
   // normalize our PLC errors to server errors
@@ -15,6 +15,10 @@ export const handler: ErrorRequestHandler = (err, req, res, next) => {
   } else {
     req.log.error(err, 'unexpected internal server error')
   }
+  if (releaseUnhandledUpgrade(req)) {
+    return
+  }
+
   if (res.headersSent) {
     return next(err)
   }
@@ -23,6 +27,24 @@ export const handler: ErrorRequestHandler = (err, req, res, next) => {
   } else {
     return res.status(500).json({ message: 'Internal Server Error' })
   }
+}
+
+/**
+ * Releases the raw socket behind an upgrade request that no route took
+ * ownership of, and reports whether it did. Returns false for ordinary
+ * requests, which still want a normal response.
+ *
+ * Both error paths need this. Express skips plain middleware once an error is
+ * in flight, so the cleanup middleware at the end of the stack is unreachable
+ * from either of them, and an upgrade's `res` is a detached dummy that swallows
+ * whatever is written to it — leaving the client hanging until it times out.
+ */
+export const releaseUnhandledUpgrade = (req: Request): boolean => {
+  if (req.ws && req.ws.handled === false) {
+    req.ws.socket.destroy()
+    return true
+  }
+  return false
 }
 
 export class ServerError extends Error {

--- a/packages/server/src/error.ts
+++ b/packages/server/src/error.ts
@@ -39,12 +39,13 @@ export const handler: ErrorRequestHandler = (err, req, res, next) => {
  * from either of them, and an upgrade's `res` is a detached dummy that swallows
  * whatever is written to it — leaving the client hanging until it times out.
  */
-export const releaseUnhandledUpgrade = (req: Request): boolean => {
-  if (req.ws && req.ws.handled === false) {
-    req.ws.socket.destroy()
-    return true
-  }
-  return false
+export const ownsUnhandledUpgrade = (req: Request): boolean =>
+  req.ws !== undefined && req.ws.handled === false
+
+const releaseUnhandledUpgrade = (req: Request): boolean => {
+  if (!ownsUnhandledUpgrade(req)) return false
+  req.ws?.socket.destroy()
+  return true
 }
 
 export class ServerError extends Error {

--- a/packages/server/src/handler.ts
+++ b/packages/server/src/handler.ts
@@ -1,6 +1,6 @@
 import type { NextFunction, Request, RequestHandler, Response } from 'express'
 import { PlcError } from '@did-plc/lib'
-import { ServerError } from './error.js'
+import { ServerError, releaseUnhandledUpgrade } from './error.js'
 
 export type RouteHandler = (req: Request, res: Response) => Promise<unknown>
 
@@ -28,6 +28,9 @@ export const handler =
             { error: { message: mapped.message, status: mapped.status } },
             'handled server error',
           )
+          if (releaseUnhandledUpgrade(req)) {
+            return
+          }
           res.status(mapped.status).json({ message: mapped.message })
           return
         }

--- a/packages/server/src/handler.ts
+++ b/packages/server/src/handler.ts
@@ -1,6 +1,6 @@
 import type { NextFunction, Request, RequestHandler, Response } from 'express'
 import { PlcError } from '@did-plc/lib'
-import { ServerError, releaseUnhandledUpgrade } from './error.js'
+import { ServerError, ownsUnhandledUpgrade } from './error.js'
 
 export type RouteHandler = (req: Request, res: Response) => Promise<unknown>
 
@@ -22,15 +22,19 @@ export const handler =
         await fn(req, res)
       } catch (err) {
         const mapped = PlcError.is(err) ? ServerError.fromPlcError(err) : err
-        if (ServerError.is(mapped) && mapped.status < 500 && !res.headersSent) {
+        // An unhandled upgrade has no usable response to answer on, so it is
+        // forwarded for error.handler to release instead of resolved here.
+        if (
+          ServerError.is(mapped) &&
+          mapped.status < 500 &&
+          !res.headersSent &&
+          !ownsUnhandledUpgrade(req)
+        ) {
           // Mirrors the log line error.handler emits for sub-500 errors.
           req.log.debug(
             { error: { message: mapped.message, status: mapped.status } },
             'handled server error',
           )
-          if (releaseUnhandledUpgrade(req)) {
-            return
-          }
           res.status(mapped.status).json({ message: mapped.message })
           return
         }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -40,10 +40,13 @@ export class PlcServer {
     sequencer?: SequencerOptions
   }): PlcServer {
     const app = express()
-    app.use(express.json({ limit: '100kb' }))
     app.use(cors())
 
     app.use(loggerMiddleware)
+    // Must come after loggerMiddleware: the body parser rejects malformed and
+    // oversized bodies by handing the error straight to error.handler, which
+    // needs req.log to already be attached.
+    app.use(express.json({ limit: '100kb' }))
 
     // Initialize sequencer
     const sequencer = new Sequencer(opts.db as Database, opts.sequencer)

--- a/packages/server/tests/error-handling.test.ts
+++ b/packages/server/tests/error-handling.test.ts
@@ -1,0 +1,167 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
+import { PassThrough } from 'stream'
+import WebSocket from 'ws'
+import type { Request, Response } from 'express'
+import * as error from '../src/error.js'
+import type { CloseFn, TestServerInfo } from './_util.js'
+import { runTestServer } from './_util.js'
+
+describe('error handling', () => {
+  let server: TestServerInfo
+  let close: CloseFn
+
+  beforeAll(async () => {
+    server = await runTestServer({ dbSchema: 'error_handling' })
+    close = server.close
+  })
+
+  afterAll(async () => {
+    if (close) await close()
+  })
+
+  describe('malformed request bodies', () => {
+    it('answers a malformed JSON body with 400 and a JSON error', async () => {
+      const res = await fetch(
+        `${server.url}/did:plc:aaaaaaaaaaaaaaaaaaaaaaaa`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: '{"not":"valid",',
+        },
+      )
+
+      // The body parser rejects with a 400. Reaching the error handler before
+      // the logger is installed used to make the handler itself throw, which
+      // finalhandler turned into a 500 with an HTML body.
+      expect(res.status).toBe(400)
+      expect(res.headers.get('content-type')).toMatch(/application\/json/)
+      await expect(res.json()).resolves.toMatchObject({
+        message: expect.any(String),
+      })
+    })
+
+    it('still answers an oversized body with 413 and a JSON error', async () => {
+      const res = await fetch(
+        `${server.url}/did:plc:aaaaaaaaaaaaaaaaaaaaaaaa`,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ padding: 'x'.repeat(200 * 1024) }),
+        },
+      )
+
+      expect(res.status).toBe(413)
+      expect(res.headers.get('content-type')).toMatch(/application\/json/)
+    })
+  })
+
+  describe('websocket upgrades that fail before being handled', () => {
+    // Connects and resolves with how the socket ended. A leaked socket never
+    // ends on its own, so it resolves 'open' once the timeout elapses.
+    const connect = (url: string, timeoutMs = 2000) =>
+      new Promise<'closed' | 'errored' | 'open'>((resolve) => {
+        const ws = new WebSocket(url)
+        const timer = setTimeout(() => {
+          ws.terminate()
+          resolve('open')
+        }, timeoutMs)
+        const settle = (how: 'closed' | 'errored') => {
+          clearTimeout(timer)
+          ws.terminate()
+          resolve(how)
+        }
+        ws.on('close', () => settle('closed'))
+        ws.on('error', () => settle('errored'))
+        ws.on('unexpected-response', () => settle('closed'))
+      })
+
+    const wsUrl = () =>
+      server.url.replace('http://', 'ws://') + '/export/stream'
+
+    // An error thrown on an upgrade request reaches the error handler while
+    // `req.ws.handled` is still false. Express skips plain middleware once it
+    // is in the error chain, so the cleanup middleware registered after the
+    // handler never runs and the connection is stranded.
+    it('does not leave the socket open when the cursor is invalid', async () => {
+      await expect(connect(`${wsUrl()}?cursor=-1`)).resolves.not.toBe('open')
+    })
+
+    it('does not leave the socket open when the cursor is not a number', async () => {
+      await expect(connect(`${wsUrl()}?cursor=banana`)).resolves.not.toBe(
+        'open',
+      )
+    })
+
+    it('does not leave the socket open when the route itself rejects', async () => {
+      // `/not-a-did` matches the `/:did` route, which rejects it as a malformed
+      // DID. Same leak, reached without going near /export/stream.
+      const url = server.url.replace('http://', 'ws://') + '/not-a-did'
+      await expect(connect(url)).resolves.not.toBe('open')
+    })
+
+    it('still closes upgrades to paths that match no route', async () => {
+      // Control: no error is raised, so the cleanup middleware is reached and
+      // has always handled this. Guards it against regressing.
+      const url = server.url.replace('http://', 'ws://') + '/a/b/c/d'
+      await expect(connect(url)).resolves.not.toBe('open')
+    })
+  })
+  // The 4xx paths above go through the route wrapper, which answers locally and
+  // never reaches error.handler. 5xx and anything unexpected still do, so the
+  // handler needs the same release; these cover that branch directly.
+  describe('error.handler on an unhandled upgrade', () => {
+    const fakeReq = (handled: boolean) => {
+      const socket = new PassThrough()
+      const destroy = vi.spyOn(socket, 'destroy')
+      const req = {
+        log: { debug: vi.fn(), error: vi.fn() },
+        ws: { socket, head: Buffer.alloc(0), handled },
+      } as unknown as Request
+      return { req, destroy }
+    }
+
+    const fakeRes = () => {
+      const res = {
+        headersSent: false,
+        status: vi.fn(() => res),
+        json: vi.fn(() => res),
+      }
+      return res as unknown as Response & { status: ReturnType<typeof vi.fn> }
+    }
+
+    it('destroys the socket instead of writing a response', () => {
+      const { req, destroy } = fakeReq(false)
+      const res = fakeRes()
+      const next = vi.fn()
+
+      error.handler(new Error('boom'), req, res, next)
+
+      expect(destroy).toHaveBeenCalledOnce()
+      expect(res.status).not.toHaveBeenCalled()
+      expect(next).not.toHaveBeenCalled()
+    })
+
+    it('leaves a socket alone once a route has taken it over', () => {
+      // `handled` is true from the moment handleUpgrade runs, after which the
+      // websocket owns the socket and must not be destroyed underneath it.
+      const { req, destroy } = fakeReq(true)
+      const res = fakeRes()
+
+      error.handler(new Error('boom'), req, res, vi.fn())
+
+      expect(destroy).not.toHaveBeenCalled()
+      expect(res.status).toHaveBeenCalledWith(500)
+    })
+
+    it('answers ordinary requests normally', () => {
+      const res = fakeRes()
+      const req = {
+        log: { debug: vi.fn(), error: vi.fn() },
+      } as unknown as Request
+
+      error.handler(new error.ServerError(400, 'nope'), req, res, vi.fn())
+
+      expect(res.status).toHaveBeenCalledWith(400)
+    })
+  })
+})


### PR DESCRIPTION
Malformed JSON bodies answered 500 with an HTML page instead of 400 with JSON, and oversized bodies 500 instead of 413. The body parser ran ahead of the logger middleware, so a body it rejected reached the error handler before `req.log` existed and the handler threw on its own log call. The parser now runs after the logger.

A websocket upgrade that fails before a route takes it over left the connection open with no response, so clients hung until they timed out. Reachable through `/export/stream` with an invalid cursor, or any upgrade to a path matching `/:did`. Neither error path can reach the cleanup middleware at the end of the stack, so both now release the socket themselves.

Both paths are covered by tests, plus a control for upgrades to a path matching no route.
